### PR TITLE
Frontend: Fixed header link for navbar when not logged in

### DIFF
--- a/frontend/src/components/navbar/NavbarNotLoggedIn.vue
+++ b/frontend/src/components/navbar/NavbarNotLoggedIn.vue
@@ -1,6 +1,6 @@
 <template>
   <b-navbar toggleable="lg" type="dark" variant="dark">
-    <b-navbar-brand to="#">TSG</b-navbar-brand>
+    <b-navbar-brand to="/">TSG</b-navbar-brand>
 
     <b-navbar-toggle target="nav-collapse"/>
 


### PR DESCRIPTION
It was not possible to go back to the main page, if not logged in. Changed `#`to `/`.